### PR TITLE
Update main.js

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -122,6 +122,16 @@ page.onResourceRequested = function(request, networkRequest) {
     id = options.transport.instrumentedFiles + '/' + id;
     fs.write(id, content, 'w');
     networkRequest.changeUrl(prefix + id);
+     if(isHttp || isHttps)
+     {
+       //get the hostname from the request object.
+       var hostname = request.url.replace(prefix, '').split('/')[0];
+       networkRequest.changeUrl(prefix + hostname + '/' + id); /*For HTML test files served by a web server (e.g., localhost),
+                                                                 the change Url MUST include the hostname else the Url is unresolved
+                                                                 which generates an error in PhantomJS.*/ 
+     }else{
+       networkRequest.changeUrl(prefix + id); 
+     }
   }
 
   // process file based ressources


### PR DESCRIPTION
When executing the qunit task which tests HTML files served by a web server (e.g., localhost), Phantom will generate an error when it attempts to changeUrl() for a unresolvable Url. If the hostname is included in the Url the change Url is resolvable (hence the modification below). Not sure if this is a bug or is a Windows specific issue. 